### PR TITLE
Add Python backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ O **Next_Page** é um editor de documentos on-line colaborativo que integra, de 
 > Nesta seção, adicione as dependências e frameworks utilizados, por exemplo:  
 > - Frontend:  `React` + `TypeScript`  
 > - Editor de Texto:   
-> - Backend: 
+> - Backend: `Python` + `FastAPI`
 > - Banco de Dados: 
 > - Comunicação em Tempo Real:
 > - Controle de Versão Interno:   
 
 ## Pré-requisitos
+- [ ] Python 3.11 ou superior
 - [ ] Node.js (versão X.X.X ou superior)  
 
 ## Como Executar

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# Next_Page Backend
+
+Esta pasta contém o código inicial do back-end em Python utilizando FastAPI.
+
+## Como rodar
+
+1. Instale as dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Execute o servidor:
+   ```bash
+   uvicorn app.main:app --reload
+   ```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Next_Page API")
+
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to Next_Page API"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add initial Python backend using FastAPI
- document backend in README
- mention Python prerequisites and backend tech in main README

## Testing
- `python3 -m py_compile backend/app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848bc10b490832b93b8766b92c8808a