### PR TITLE
Add React Router and login redirect

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -1,13 +1,15 @@
-import { useState } from 'react'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import Login from './Pages/Login.jsx'
 import Register from './Pages/Register.jsx'
-
+import Editor from './Pages/Editor.jsx'
 function App() {
-  const [page, setPage] = useState('login')
-  return page === 'login' ? (
-    <Login onShowRegister={() => setPage('register')} />
-  ) : (
-    <Register onShowLogin={() => setPage('login')} />
+  return (
+    <Routes>
+      <Route path="/" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+      <Route path="/editor" element={<Editor />} />
+      <Route path="*" element={<Navigate to="/" />} />
+    </Routes>
   )
 }
 

--- a/Frontend/src/Pages/Editor.jsx
+++ b/Frontend/src/Pages/Editor.jsx
@@ -1,3 +1,5 @@
+import BackButton from '../components/BackButton.jsx'
+
 function Editor() {
   const pageStyle = { fontFamily: 'Manrope, "Noto Sans", sans-serif' }
   const avatarStyle = { backgroundImage: 'url("https://lh3.googleusercontent.com/aida-public/AB6AXuDm3TJQ2bsuTFWymc2Zk_ul_UFNWm9sNykIz-NMHhL0PoS12Fi486mWOZAn3_x22WDH8S0e4rhwVEmLCTpnn9njxyHcw1I_XeGkUReoLJH4uU6tSBqiAHt9mt0NycVBgx6EjInl8KMxpeLk83j0Y_FpT2REm6zfpNrhd_kVJvxKm2NU8HqgCSs0y84v--Shy1_kE_ZEqg1e8a22HZDG4b8vqbjg12BnuFRUk1gaNbl5ySWLhWKtgGNSnf6NVQhfHyjeDroohmI8BH5_")' }
@@ -6,6 +8,7 @@ function Editor() {
       <div className="layout-container flex h-full grow flex-col">
         <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-slate-200 bg-white px-6 py-3 shadow-sm">
           <div className="flex items-center gap-3 text-slate-800">
+            <BackButton className="mr-2" />
             <div className="size-6 text-blue-600">
               <svg fill="none" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
                 <path d="M24 45.8096C19.6865 45.8096 15.4698 44.5305 11.8832 42.134C8.29667 39.7376 5.50128 36.3314 3.85056 32.3462C2.19985 28.361 1.76794 23.9758 2.60947 19.7452C3.451 15.5145 5.52816 11.6284 8.57829 8.5783C11.6284 5.52817 15.5145 3.45101 19.7452 2.60948C23.9758 1.76795 28.361 2.19986 32.3462 3.85057C36.3314 5.50129 39.7376 8.29668 42.134 11.8833C44.5305 15.4698 45.8096 19.6865 45.8096 24L24 24L24 45.8096Z" fill="currentColor" />

--- a/Frontend/src/Pages/Login.jsx
+++ b/Frontend/src/Pages/Login.jsx
@@ -1,12 +1,14 @@
 import { useState, useRef } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import './Login.css'
 import logo from '../assets/logo1.png'
 
-function Login({ onShowRegister }) {
+function Login() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const errorRef = useRef(null)
+  const navigate = useNavigate()
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -27,7 +29,7 @@ function Login({ onShowRegister }) {
         }
       } else {
         setError('')
-        alert('Login successful!')
+        navigate('/editor')
       }
     } catch (err) {
       setError('Network error')
@@ -105,7 +107,7 @@ function Login({ onShowRegister }) {
           </form>
           <p className="mt-8 text-center text-sm text-slate-600">
             New to Next_Page?
-            <a className="font-medium text-[#0c7ff2] hover:text-[#0a68c4]" href="#" onClick={onShowRegister}> Create an account</a>
+            <Link className="font-medium text-[#0c7ff2] hover:text-[#0a68c4]" to="/register"> Create an account</Link>
           </p>
         </div>
         <footer className="mt-10 text-black-600 text-center text-sm text-slate-400">

--- a/Frontend/src/Pages/Register.jsx
+++ b/Frontend/src/Pages/Register.jsx
@@ -1,12 +1,14 @@
 import { useState, useRef } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import './Login.css'
 import logo from '../assets/logo1.png'
 
-function Register({ onShowLogin }) {
+function Register() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const errorRef = useRef(null)
+  const navigate = useNavigate()
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -27,8 +29,7 @@ function Register({ onShowLogin }) {
         }
       } else {
         setError('')
-        alert('Registration successful!')
-        onShowLogin()
+        navigate('/')
       }
     } catch (err) {
       setError('Network error')
@@ -101,7 +102,7 @@ function Register({ onShowLogin }) {
           </form>
           <p className="mt-8 text-center text-sm text-slate-600">
             Already have an account?
-            <a className="font-medium text-[#0c7ff2] hover:text-[#0a68c4]" href="#" onClick={onShowLogin}> Sign in</a>
+            <Link className="font-medium text-[#0c7ff2] hover:text-[#0a68c4]" to="/"> Sign in</Link>
           </p>
         </div>
         <footer className="mt-10 text-black-600 text-center text-sm text-slate-400">

--- a/Frontend/src/components/BackButton.jsx
+++ b/Frontend/src/components/BackButton.jsx
@@ -1,0 +1,16 @@
+import { useNavigate } from 'react-router-dom'
+
+function BackButton({ className = '' }) {
+  const navigate = useNavigate()
+  return (
+    <button
+      onClick={() => navigate(-1)}
+      className={`text-slate-600 hover:text-slate-800 ${className}`}
+      aria-label="Go back"
+    >
+      <span className="material-icons">arrow_back</span>
+    </button>
+  )
+}
+
+export default BackButton

--- a/Frontend/src/main.jsx
+++ b/Frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add React Router dependency
- route pages through `react-router-dom`
- redirect to editor after login
- link registration and login pages
- add back button component and show it in Editor

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68630ee1c0288330971d86fd2a2f4747