### PR TITLE
Implement A4 layout for editor

### DIFF
--- a/Frontend/src/Pages/Editor.jsx
+++ b/Frontend/src/Pages/Editor.jsx
@@ -1,6 +1,19 @@
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
+import HorizontalRule from '@tiptap/extension-horizontal-rule'
+
+const PageBreak = HorizontalRule.extend({
+  name: 'pageBreak',
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Enter': () => this.editor.commands.setHorizontalRule(),
+    }
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['hr', { ...HTMLAttributes, class: 'page-break' }]
+  },
+})
 
 function Editor() {
   const pageStyle = { fontFamily: 'Manrope, "Noto Sans", sans-serif' }
@@ -12,6 +25,7 @@ function Editor() {
       Placeholder.configure({
         placeholder: 'Start typing your document here...'
       }),
+      PageBreak,
     ],
     content: '',
   })
@@ -80,11 +94,13 @@ function Editor() {
                   <span>Saved</span>
                 </div>
               </div>
-              <div className="p-1">
-                <EditorContent
-                  editor={editor}
-                  className="form-textarea w-full resize-none overflow-hidden rounded-md text-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent border-transparent bg-white min-h-[calc(100vh-200px)] p-6 text-base font-normal leading-relaxed"
-                />
+              <div className="p-1 flex justify-center">
+                <div className="editor-page">
+                  <EditorContent
+                    editor={editor}
+                    className="w-full h-full outline-none"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -64,3 +64,17 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.editor-page {
+  width: 210mm;
+  min-height: 297mm;
+  margin: 20px auto;
+  padding: 20mm 25mm;
+  background: white;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+}
+
+.page-break {
+  border: 1px dashed #bbb;
+  margin: 32px 0;
+}


### PR DESCRIPTION
## Summary
- style editor page like an A4 sheet
- allow inserting page breaks with `Ctrl+Enter`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686368bce91c833089122197876de966