### PR TITLE
Fix editor text color and A4 size

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -67,11 +67,13 @@ button:focus-visible {
 
 .editor-page {
   width: 210mm;
-  min-height: 297mm;
+  height: 297mm;
   margin: 20px auto;
   padding: 20mm 25mm;
   background: white;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  color: #000;
 }
 
 .page-break {


### PR DESCRIPTION
## Summary
- ensure the editor text is visible by forcing black text
- keep the editor area fixed to A4 dimensions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68649fb0c7bc8330b77d2b1e91b842ea