### PR TITLE
Implement simple document commit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ cd next_page
 - npm install react-router-dom
 - npm run dev
 
+## Novas rotas da API
+Com o backend rodando em `http://localhost:8000`, as seguintes rotas permitem
+persistir documentos simples em um repositório Git para cada usuário:
+
+- `POST /api/save` salva o conteúdo enviado e cria um commit.
+- `GET /api/history/{email}` retorna a lista de commits do usuário.
+


### PR DESCRIPTION
## Summary
- allow backend to store documents in git repositories
- expose `/api/save` and `/api/history/{email}`
- document new API routes in README

## Testing
- `python -m py_compile Backend/main.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pip install GitPython` *(fails: Tunnel connection failed 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_686aafa627d483338c1e3e79491b5cd1