### PR TITLE
Enable automatic page creation

### DIFF
--- a/Frontend/src/Extensions/PageBreak.js
+++ b/Frontend/src/Extensions/PageBreak.js
@@ -1,0 +1,27 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+
+export const PageBreak = Node.create({
+  name: 'pageBreak',
+  group: 'block',
+  atom: true,
+  selectable: false,
+
+  parseHTML() {
+    return [
+      { tag: 'div[data-page-break]' },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-page-break': '', class: 'page-break' })]
+  },
+
+  addCommands() {
+    return {
+      insertPageBreak:
+        () => ({ chain }) => {
+          return chain().insertContent({ type: this.name }).run()
+        },
+    }
+  },
+})

--- a/Frontend/src/Extensions/Pagination.js
+++ b/Frontend/src/Extensions/Pagination.js
@@ -1,0 +1,44 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from 'prosemirror-state'
+
+export const Pagination = Extension.create({
+  name: 'pagination',
+
+  addProseMirrorPlugins() {
+    const pageHeight = 1122 // roughly 297mm in pixels
+
+    const countBreaks = doc => {
+      let count = 0
+      doc.descendants(node => {
+        if (node.type.name === 'pageBreak') count++
+      })
+      return count
+    }
+
+    return [
+      new Plugin({
+        key: new PluginKey('pagination'),
+        view: view => {
+          const check = () => {
+            const docHeight = view.dom.scrollHeight
+            const breaks = countBreaks(view.state.doc)
+            if (docHeight > pageHeight * (breaks + 1)) {
+              const tr = view.state.tr.insert(view.state.doc.content.size, view.state.schema.nodes.pageBreak.create())
+              view.dispatch(tr)
+            }
+          }
+
+          setTimeout(check, 0)
+
+          return {
+            update(view, prevState) {
+              if (!view.state.doc.eq(prevState.doc)) {
+                setTimeout(check, 0)
+              }
+            },
+          }
+        },
+      }),
+    ]
+  },
+})

--- a/Frontend/src/Extensions/Pagination.js
+++ b/Frontend/src/Extensions/Pagination.js
@@ -21,8 +21,9 @@ export const Pagination = Extension.create({
         view: view => {
           const check = () => {
             const docHeight = view.dom.scrollHeight
-            const breaks = countBreaks(view.state.doc)
-            if (docHeight > pageHeight * (breaks + 1)) {
+            const expectedBreaks = Math.floor(docHeight / pageHeight)
+            const currentBreaks = countBreaks(view.state.doc)
+            if (expectedBreaks > currentBreaks) {
               const tr = view.state.tr.insert(view.state.doc.content.size, view.state.schema.nodes.pageBreak.create())
               view.dispatch(tr)
             }

--- a/Frontend/src/Pages/Editor.jsx
+++ b/Frontend/src/Pages/Editor.jsx
@@ -1,7 +1,9 @@
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import CharacterCount from '@tiptap/extension-character-count';
+import CharacterCount from '@tiptap/extension-character-count'
 import Placeholder from '@tiptap/extension-placeholder'
+import { PageBreak } from '../Extensions/PageBreak'
+import { Pagination } from '../Extensions/Pagination'
 
 function Editor() {
   const pageStyle = { fontFamily: 'Manrope, "Noto Sans", sans-serif' }
@@ -10,6 +12,8 @@ function Editor() {
   const editor = useEditor({
     extensions: [
       StarterKit,
+      PageBreak,
+      Pagination,
       CharacterCount.configure({
         limit: 2600,   // bloqueia input, inclusive colar
         mode: 'nodeSize',   // usa o contador padrão

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -91,6 +91,7 @@ button:focus-visible {
 }
 
 .page-break {
-  border: 1px dashed #bbb;
+  border-top: 1px dashed #bbb;
   margin: 32px 0;
+  width: 100%;
 }

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -67,11 +67,10 @@ button:focus-visible {
 
 .editor-page {
   width: 210mm;
-  height: 297mm;
+  min-height: 297mm;
   margin: 20px auto;
   padding: 20mm 25mm;
   background: white;
-  overflow: hidden;
   color: #000;
 }
 
@@ -79,19 +78,18 @@ button:focus-visible {
   outline: none; /* remove contorno preto */
   box-sizing: border-box;
   max-width: 100%;
-  max-height: 100%;
   overflow-wrap: break-word;
   word-break: break-word;
 }
 
 .editor-page .ProseMirror {
   width: 210mm;
-  height: 297mm;
-  overflow-y: hidden;
+  min-height: 297mm;
 }
 
 .page-break {
   border-top: 1px dashed #bbb;
   margin: 32px 0;
   width: 100%;
+  page-break-after: always;
 }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ O **Next_Page** é um editor de documentos on-line colaborativo que integra, de 
 - **Histórico de Alterações**  
   Visualize todas as mudanças realizadas, com autor, timestamp e mensagem de commit.
 
-- **Resolução de Conflitos**  
+- **Resolução de Conflitos**
   Interface para identificar e mesclar trechos conflitantes.
+- **Paginação Automática**
+  Novas páginas A4 são criadas conforme o conteúdo excede o espaço disponível.
 
 ## Tecnologias (a definir)
 > Nesta seção, adicione as dependências e frameworks utilizados, por exemplo:  

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ O **Next_Page** é um editor de documentos on-line colaborativo que integra, de 
 - **Resolução de Conflitos**
   Interface para identificar e mesclar trechos conflitantes.
 - **Paginação Automática**
-  Novas páginas A4 são criadas conforme o conteúdo excede o espaço disponível.
+  Páginas adicionais no formato A4 aparecem automaticamente quando o texto ultrapassa o limite da página atual, assim como em editores tradicionais.
 
 ## Tecnologias (a definir)
 > Nesta seção, adicione as dependências e frameworks utilizados, por exemplo:  


### PR DESCRIPTION
## Summary
- implement `PageBreak` node extension for Tiptap
- add `Pagination` plugin to detect overflow and insert page breaks
- integrate pagination features in the editor
- style page break line
- document the new automatic pagination feature

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b33c530088330ad95d8c320db8e1a