### PR TITLE
Add editor fetch/save by id

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import Login from './Pages/Login.jsx'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import Register from './Pages/Register.jsx'
@@ -9,7 +8,7 @@ function App() {
     <Routes>
       <Route path="/" element={<Login />} />
       <Route path="/register" element={<Register />} />
-      <Route path="/editor" element={<Editor />} />
+      <Route path="/editor/:id" element={<Editor />} />
       <Route path="*" element={<Navigate to="/" />} />
     </Routes>
   )


### PR DESCRIPTION
## Summary
- load and store editor content using document ID from the URL
- expose editor route with parameter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687718e5d8a48330b48d84571ef5bf86