### PR TITLE
Fix project listing when no projects

### DIFF
--- a/Frontend/src/Pages/Projects.jsx
+++ b/Frontend/src/Pages/Projects.jsx
@@ -17,9 +17,19 @@ function Projects() {
           'Authorization': `Bearer ${token}`,
         }
       })
-      .then(res => res.json())
-      .then(data => setProjects(data))
-      .catch(console.error)
+      .then(async res => {
+        if (!res.ok) return []
+        try {
+          return await res.json()
+        } catch {
+          return []
+        }
+      })
+      .then(data => {
+        if (Array.isArray(data)) setProjects(data)
+        else setProjects([])
+      })
+      .catch(() => setProjects([]))
   }, [])
   return (
     <div className="bg-slate-50 min-h-screen">
@@ -93,7 +103,7 @@ function Projects() {
                     {projects.length === 0 && (
                       <tr>
                         <td colSpan={4} className="px-6 py-4 text-center text-sm text-slate-500">
-                          No projects found.
+                          Não foram encontrados projetos anteriores.
                         </td>
                       </tr>
                     )}

--- a/Frontend/src/main.jsx
+++ b/Frontend/src/main.jsx
@@ -8,7 +8,6 @@ import { UserProvider } from './Pages/UserContext.jsx'
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
       <UserProvider>
         <App />
       </UserProvider>


### PR DESCRIPTION
## Summary
- make `Projects.jsx` resilient to non-array responses
- show a Portuguese message when no projects are returned

## Testing
- `npm run lint` *(failed: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688117362edc8330acad65900df68b46