### PR TITLE
Make Next_Page logo link to projects

### DIFF
--- a/Frontend/src/Pages/Editor.jsx
+++ b/Frontend/src/Pages/Editor.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useContext, useCallback, useRef } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import TextAlign from '@tiptap/extension-text-align'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 import StarterKit from '@tiptap/starter-kit'
 import Italic from '@tiptap/extension-italic'
 import Heading from '@tiptap/extension-heading'
@@ -236,18 +236,18 @@ function Editor({ editable = true }) {
     <div className="bg-slate-100" style={pageStyle}>
       <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#625DF5] to-transparent p-6">
         <header className="w-full max-w-4xl flex items-center justify-between whitespace-nowrap border-b border-solid border-slate-200 bg-transparent px-6 py-3 shadow-sm mb-6 rounded-t-xl">
-          <div className="flex items-center gap-3 text-white">
+          <Link to="/projects" className="flex items-center gap-3 text-white">
             <div className="inline-flex items-center justify-center bg-white rounded-full p-2">
               <img
                 src={logo}
                 alt="Logo"
                 className="w-20 h-20"
-                style={{ fontFamily: 'Manrope, "Noto Sans", sans-serif' }}
+                style={{ fontFamily: 'Manrope, \"Noto Sans\", sans-serif' }}
               />
             </div>
 
             <h1 className="text-2xl font-bold tracking-tight">Next_Page</h1>
-          </div>
+          </Link>
           <div className="flex flex-1 items-center justify-end gap-6 relative">
             {/* Botões de ação */}
             <div className="flex items-center gap-2">

--- a/Frontend/src/Pages/Login.jsx
+++ b/Frontend/src/Pages/Login.jsx
@@ -34,10 +34,10 @@ function Login() {
       <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#625DF5] to-transparent p-6">
         <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-2xl">
           <div className="mb-8 flex flex-col items-center">
-            <div className="mb-4 flex items-center gap-3 text-slate-800">
+          <Link to="/projects" className="mb-4 flex items-center gap-3 text-slate-800">
               <img src={logo} alt="Logo" className="w-20 h-20" />
               <h1 className="text-3xl font-bold tracking-tight">Next_Page</h1>
-            </div>
+            </Link>
             <p className="text-slate-600">Welcome back! Please sign in to your account.</p>
           </div>
           <form className="space-y-6" onSubmit={handleSubmit}>

--- a/Frontend/src/Pages/Projects.jsx
+++ b/Frontend/src/Pages/Projects.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext, useRef } from 'react'
 import { UserContext } from './UserContext.jsx'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import logo from '../assets/logo1.png'
 
 export default function Projects() {
@@ -63,14 +63,14 @@ export default function Projects() {
       {/* HEADER FIXO */}
       <header className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-b from-[#625DF5] to-transparent border-b border-slate-200">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
-          <div className="flex items-center gap-4 text-white">
+          <Link to="/projects" className="flex items-center gap-4 text-white">
             <img
               src={logo}
               alt="Logo"
               className="w-12 h-12 rounded-full bg-white p-1"
             />
             <span className="text-2xl font-bold">Next_Page</span>
-          </div>
+          </Link>
           <div className="flex items-center gap-4 relative">
             <input
               type="text"

--- a/Frontend/src/Pages/Register.jsx
+++ b/Frontend/src/Pages/Register.jsx
@@ -42,10 +42,10 @@ function Register() {
       <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#625DF5] to-transparent p-6">
         <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-2xl">
           <div className="mb-8 flex flex-col items-center">
-            <div className="mb-4 flex items-center gap-3 text-slate-800">
+          <Link to="/projects" className="mb-4 flex items-center gap-3 text-slate-800">
               <img src={logo} alt="Logo" className="w-20 h-20" />
               <h1 className="text-3xl font-bold tracking-tight">Next_Page</h1>
-            </div>
+            </Link>
             <p className="text-slate-600">Create your account.</p>
           </div>
           <form className="space-y-6" onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- link the Next_Page logo on Login, Register, Projects and Editor pages to `/projects`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68847c3b446c8330958288ebc64ecb57