### PR TITLE
Fix project title persistence

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -280,10 +280,14 @@ async def save_document(
             repo.index.commit(data.message or "Update",
                               author=actor, committer=actor)
 
-    # mongo.update_project(document, {"Texto": data.content})
     update_fields: dict[str, str] = {"Texto": data.content}
     if data.title is not None:
         update_fields["nomeProjeto"] = data.title
+
+    # Persist updated text and optional title in MongoDB
+    if update_fields:
+        mongo.update_project(document, update_fields)
+
     return {"msg": "Document saved"}
 
 

--- a/Frontend/src/Pages/Editor.jsx
+++ b/Frontend/src/Pages/Editor.jsx
@@ -177,7 +177,12 @@ function Editor({ editable = true }) {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${token}`,
         },
-        body: JSON.stringify({ content, message, branch: currentBranch }),
+        body: JSON.stringify({
+          content,
+          message,
+          branch: currentBranch,
+          title,
+        }),
       })
       .then(res => {
         if (!res.ok) throw new Error('save failed')
@@ -186,7 +191,7 @@ function Editor({ editable = true }) {
       .catch(() => {
         setSaveStatus('error')
       })
-  }, [content, id, token, currentBranch])
+  }, [content, id, token, currentBranch, title])
 
   useEffect(() => {
     const handler = setTimeout(() => {


### PR DESCRIPTION
## Summary
- persist title updates in backend when saving
- include title in save request from editor

## Testing
- `python3 -m py_compile Backend/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6887084a5c8483308757964564226076