### PR TITLE
Add navigation to projects on logo click

### DIFF
--- a/Frontend/src/Pages/Editor.jsx
+++ b/Frontend/src/Pages/Editor.jsx
@@ -447,7 +447,10 @@ function Editor({ editable = true }) {
 
       <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#625DF5] to-transparent p-6">
         <header className="w-full max-w-4xl flex items-center justify-between whitespace-nowrap border-b border-solid border-slate-200 bg-transparent px-6 py-3 shadow-sm mb-6 rounded-t-xl">
-          <div className="flex items-center gap-3 text-white">
+          <div
+            className="flex items-center gap-3 text-white cursor-pointer"
+            onClick={() => navigate('/projects')}
+          >
             <div className="inline-flex items-center justify-center bg-white rounded-full p-2">
               <img
                 src={logo}

--- a/Frontend/src/Pages/Login.jsx
+++ b/Frontend/src/Pages/Login.jsx
@@ -34,7 +34,10 @@ function Login() {
       <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#625DF5] to-transparent p-6">
         <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-2xl">
           <div className="mb-8 flex flex-col items-center">
-            <div className="mb-4 flex items-center gap-3 text-slate-800">
+            <div
+              className="mb-4 flex items-center gap-3 text-slate-800 cursor-pointer"
+              onClick={() => navigate('/projects')}
+            >
               <img src={logo} alt="Logo" className="w-20 h-20" />
               <h1 className="text-3xl font-bold tracking-tight">Next_Page</h1>
             </div>

--- a/Frontend/src/Pages/Projects.jsx
+++ b/Frontend/src/Pages/Projects.jsx
@@ -63,7 +63,10 @@ export default function Projects() {
       {/* HEADER FIXO */}
       <header className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-b from-[#625DF5] to-transparent border-b border-slate-200">
         <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
-          <div className="flex items-center gap-4 text-white">
+          <div
+            className="flex items-center gap-4 text-white cursor-pointer"
+            onClick={() => navigate('/projects')}
+          >
             <img
               src={logo}
               alt="Logo"

--- a/Frontend/src/Pages/Register.jsx
+++ b/Frontend/src/Pages/Register.jsx
@@ -42,7 +42,10 @@ function Register() {
       <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#625DF5] to-transparent p-6">
         <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-2xl">
           <div className="mb-8 flex flex-col items-center">
-            <div className="mb-4 flex items-center gap-3 text-slate-800">
+            <div
+              className="mb-4 flex items-center gap-3 text-slate-800 cursor-pointer"
+              onClick={() => navigate('/projects')}
+            >
               <img src={logo} alt="Logo" className="w-20 h-20" />
               <h1 className="text-3xl font-bold tracking-tight">Next_Page</h1>
             </div>


### PR DESCRIPTION
## Summary
- make every logo redirect to `/projects` without link styling

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_688709a1649483309811a7f332d96db0