### PR TITLE
Fix document title load

### DIFF
--- a/Frontend/src/Pages/Editor.jsx
+++ b/Frontend/src/Pages/Editor.jsx
@@ -171,6 +171,22 @@ function Editor({ editable = true }) {
     fetchHistory();
   }, [fetchHistory]);
 
+  // Load initial document content and title
+  useEffect(() => {
+    if (!id || !token || !editor) return;
+    fetch(`http://localhost:8000/api/load/${id}?branch=${currentBranch}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) {
+          editor.commands.setContent(data.content || "");
+          setTitle(data.title || "Título do Documento");
+        }
+      })
+      .catch(() => {});
+  }, [id, token, editor, currentBranch]);
+
   // MUDANÇA: A função agora pega o conteúdo direto do editor.
   const saveContent = useCallback(
     (message) => {


### PR DESCRIPTION
## Summary
- fetch document content and title when Editor opens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6887e3cae40483309b62161632762f95