### PR TITLE
Store branch information in MongoDB

### DIFF
--- a/Backend/db.py
+++ b/Backend/db.py
@@ -23,6 +23,7 @@ class Project(BaseModel):
     dono: str
     permissions: List[str] = Field(default_factory=list)
     Texto: str = ""
+    branch: str = "main"
 
 class MongoDB:
     def __init__(self):


### PR DESCRIPTION
## Summary
- track a document's default branch in `Project`
- save branch information when creating and updating a document
- expose stored branch in document listings and load endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ea5f0be48330a1a195fa59336f0c